### PR TITLE
fix(#19): set userName property when present

### DIFF
--- a/android/src/main/java/com/espidfprovisioning/EspIdfProvisioningModule.kt
+++ b/android/src/main/java/com/espidfprovisioning/EspIdfProvisioningModule.kt
@@ -193,6 +193,9 @@ class EspIdfProvisioningModule internal constructor(context: ReactApplicationCon
         espDevice.bluetoothDevice = bleDevice
         espDevice.deviceName = deviceName
         espDevice.proofOfPossession = proofOfPossession
+        if (username != null) {
+          espDevice.userName = username
+        }
 
         espDevices[deviceName] = espDevice
 
@@ -219,6 +222,9 @@ class EspIdfProvisioningModule internal constructor(context: ReactApplicationCon
 
         // Configure proof of possession
         espDevices[deviceName]?.proofOfPossession = proofOfPossession
+        if (username != null) {
+          espDevices[deviceName]?.userName = username
+        }
 
         val result = Arguments.createMap()
         result.putString("name", espDevices[deviceName]?.deviceName)


### PR DESCRIPTION
Set username when passed to `createESPDevice`, see #19 for more info.

- [x] Tested in local development build.
- [ ] Tested in beta (production-ish) build.