### PR TITLE
fix(#28): move up com.android.library to top of build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,3 +1,4 @@
+apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 
 buildscript {
@@ -14,9 +15,6 @@ buildscript {
 def isNewArchitectureEnabled() {
   return rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"
 }
-
-apply plugin: "com.android.library"
-
 
 def appProject = rootProject.allprojects.find { it.plugins.hasPlugin('com.android.application') }
 


### PR DESCRIPTION
Fixes #28 