### PR TITLE
fix(#73): fix support for new architecture

### DIFF
--- a/android/src/main/java/com/espidfprovisioning/EspIdfProvisioningModule.kt
+++ b/android/src/main/java/com/espidfprovisioning/EspIdfProvisioningModule.kt
@@ -80,7 +80,7 @@ class EspIdfProvisioningModule internal constructor(context: ReactApplicationCon
 
   @SuppressLint("MissingPermission")
   @ReactMethod
-  override fun searchESPDevices(devicePrefix: String, transport: String, security: Int, promise: Promise?) {
+  override fun searchESPDevices(devicePrefix: String, transport: String, security: Double, promise: Promise?) {
     // Permission checks
     if (!hasBluetoothPermissions() || !hasFineLocationPermission()) {
       promise?.reject(Error("Missing one of the following permissions: BLUETOOTH, BLUETOOTH_ADMIN, BLUETOOTH_CONNECT, BLUETOOTH_SCAN, ACCESS_FINE_LOCATION"))
@@ -92,7 +92,7 @@ class EspIdfProvisioningModule internal constructor(context: ReactApplicationCon
       "ble" -> ESPConstants.TransportType.TRANSPORT_BLE
       else -> ESPConstants.TransportType.TRANSPORT_BLE
     }
-    val securityEnum = when (security) {
+    val securityEnum = when (security.toInt()) {
       0 -> ESPConstants.SecurityType.SECURITY_0
       1 -> ESPConstants.SecurityType.SECURITY_1
       2 -> ESPConstants.SecurityType.SECURITY_2
@@ -140,7 +140,7 @@ class EspIdfProvisioningModule internal constructor(context: ReactApplicationCon
           val resultMap = Arguments.createMap()
           resultMap.putString("name", espDevice.deviceName)
           resultMap.putString("transport", transport)
-          resultMap.putInt("security", security)
+          resultMap.putInt("security", security.toInt())
 
           resultArray.pushMap(resultMap)
         }
@@ -171,7 +171,7 @@ class EspIdfProvisioningModule internal constructor(context: ReactApplicationCon
   override fun createESPDevice(
     deviceName: String,
     transport: String,
-    security: Int,
+    security: Double,
     proofOfPossession: String?,
     softAPPassword: String?,
     username: String?,
@@ -188,7 +188,7 @@ class EspIdfProvisioningModule internal constructor(context: ReactApplicationCon
       "ble" -> ESPConstants.TransportType.TRANSPORT_BLE
       else -> ESPConstants.TransportType.TRANSPORT_BLE
     }
-    val securityEnum = when (security) {
+    val securityEnum = when (security.toInt()) {
       0 -> ESPConstants.SecurityType.SECURITY_0
       1 -> ESPConstants.SecurityType.SECURITY_1
       2 -> ESPConstants.SecurityType.SECURITY_2
@@ -232,7 +232,7 @@ class EspIdfProvisioningModule internal constructor(context: ReactApplicationCon
       val result = Arguments.createMap()
       result.putString("name", espDevice.deviceName)
       result.putString("transport", transport)
-      result.putInt("security", security)
+      result.putInt("security", security.toInt())
 
       promise?.resolve(result)
       return
@@ -256,7 +256,7 @@ class EspIdfProvisioningModule internal constructor(context: ReactApplicationCon
         val result = Arguments.createMap()
         result.putString("name", espDevice.deviceName)
         result.putString("transport", transport)
-        result.putInt("security", security)
+        result.putInt("security", security.toInt())
 
         promise?.resolve(result)
       }
@@ -552,13 +552,13 @@ class EspIdfProvisioningModule internal constructor(context: ReactApplicationCon
   }
 
   @ReactMethod
-  override fun setSecurityType(deviceName: String, security: Int, promise: Promise?) {
+  override fun setSecurityType(deviceName: String, security: Double, promise: Promise?) {
     val espDevice = espDevices[deviceName].guard {
       promise?.reject(Error("No ESP device found. Call createESPDevice first."))
       return
     }
 
-    val securityEnum = when (security) {
+    val securityEnum = when (security.toInt()) {
       0 -> ESPConstants.SecurityType.SECURITY_0
       1 -> ESPConstants.SecurityType.SECURITY_1
       2 -> ESPConstants.SecurityType.SECURITY_2

--- a/android/src/newarch/EspIdfProvisioningSpec.java
+++ b/android/src/newarch/EspIdfProvisioningSpec.java
@@ -1,9 +1,0 @@
-package com.espidfprovisioning;
-
-import com.facebook.react.bridge.ReactApplicationContext;
-
-abstract class EspIdfProvisioningSpec extends NativeEspIdfProvisioningSpec {
-  EspIdfProvisioningSpec(ReactApplicationContext context) {
-    super(context);
-  }
-}

--- a/android/src/newarch/EspIdfProvisioningSpec.kt
+++ b/android/src/newarch/EspIdfProvisioningSpec.kt
@@ -1,0 +1,6 @@
+package com.espidfprovisioning
+
+import com.facebook.react.bridge.ReactApplicationContext
+
+abstract class EspIdfProvisioningSpec(context: ReactApplicationContext?) :
+    NativeEspIdfProvisioningSpec(context)

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -34,7 +34,7 @@ reactNativeArchitectures=armeabi-v7a,arm64-v8a,x86,x86_64
 # your application. You should enable this flag either if you want
 # to write custom TurboModules/Fabric components OR use libraries that
 # are providing them.
-newArchEnabled=false
+newArchEnabled=true
 
 # Use this property to enable or disable the Hermes JS engine.
 # If set to false, you will be using JSC instead.

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -962,7 +962,71 @@ PODS:
     - ReactCommon/turbomodule/core
     - Yoga
   - react-native-safe-area-context (4.10.4):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Codegen
     - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - react-native-safe-area-context/common (= 4.10.4)
+    - react-native-safe-area-context/fabric (= 4.10.4)
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
+  - react-native-safe-area-context/common (4.10.4):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Codegen
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
+  - react-native-safe-area-context/fabric (4.10.4):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Codegen
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - react-native-safe-area-context/common
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
   - React-nativeconfig (0.74.1)
   - React-NativeModulesApple (0.74.1):
     - glog
@@ -1215,6 +1279,29 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
+    - RNScreens/common (= 3.31.1)
+    - Yoga
+  - RNScreens/common (3.31.1):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Codegen
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-RCTImage
+    - React-rendererdebug
+    - React-utils
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
     - Yoga
   - RNVectorIcons (10.1.0):
     - DoubleConversion
@@ -1437,9 +1524,9 @@ SPEC CHECKSUMS:
   ESPProvision: 47194e8d7360bf7844a2b7f6a3aa54b8805aca5a
   FBLazyVector: 898d14d17bf19e2435cafd9ea2a1033efe445709
   fmt: 4c2741a687cc09f0634a2e2c72a838b99f1ff120
-  glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
+  glog: 69ef571f3de08433d766d614c73a9838a06bf7eb
   hermes-engine: 16b8530de1b383cdada1476cf52d1b52f0692cbc
-  RCT-Folly: 02617c592a293bd6d418e0a88ff4ee1f88329b47
+  RCT-Folly: 4464f4d875961fce86008d45f4ecf6cef6de0740
   RCTDeprecation: efb313d8126259e9294dc4ee0002f44a6f676aba
   RCTRequired: f49ea29cece52aee20db633ae7edc4b271435562
   RCTTypeSafety: a11979ff0570d230d74de9f604f7d19692157bc4
@@ -1463,16 +1550,16 @@ SPEC CHECKSUMS:
   React-jsitracing: 233d1a798fe0ff33b8e630b8f00f62c4a8115fbc
   React-logger: 7e7403a2b14c97f847d90763af76b84b152b6fce
   React-Mapbuffer: 11029dcd47c5c9e057a4092ab9c2a8d10a496a33
-  react-native-esp-idf-provisioning: fd1dfee7996896c570619b761d0864ba0eb145e1
-  react-native-safe-area-context: 399a5859f6acbdf67f671c69b53113f535f3b5b0
+  react-native-esp-idf-provisioning: 5140c7cabde635716cc5e97e8cf4c3514b4cd49e
+  react-native-safe-area-context: 2908c69c3ef0a68d536b985a76738d541d6b022e
   React-nativeconfig: b0073a590774e8b35192fead188a36d1dca23dec
   React-NativeModulesApple: df46ff3e3de5b842b30b4ca8a6caae6d7c8ab09f
   React-perflogger: 3d31e0d1e8ad891e43a09ac70b7b17a79773003a
   React-RCTActionSheet: c4a3a134f3434c9d7b0c1054f1a8cfed30c7a093
   React-RCTAnimation: 0e5d15320eeece667fcceb6c785acf9a184e9da1
-  React-RCTAppDelegate: c4f6c0700b8950a8b18c2e004996eec1807d430a
+  React-RCTAppDelegate: 3ab57e497300ec1c54b798ba2d0834ee048229f4
   React-RCTBlob: c46aaaee693d371a1c7cae2a8c8ee2aa7fbc1adb
-  React-RCTFabric: 0dbf28ce96c7f2843483e32a725a5b5793584ff3
+  React-RCTFabric: 82f15dc5a981288bfa806545f943cbd18e794ad7
   React-RCTImage: a04dba5fcc823244f5822192c130ecf09623a57f
   React-RCTLinking: 533bf13c745fcb2a0c14e0e49fd149586a7f0d14
   React-RCTNetwork: a29e371e0d363d7b4c10ab907bc4d6ae610541e9
@@ -1489,8 +1576,8 @@ SPEC CHECKSUMS:
   React-utils: 3285151c9d1e3a28a9586571fc81d521678c196d
   ReactCommon: f42444e384d82ab89184aed5d6f3142748b54768
   RNDefaultPreference: 08bdb06cfa9188d5da97d4642dac745218d7fb31
-  RNScreens: b32a9ff15bea7fcdbe5dff6477bc503f792b1208
-  RNVectorIcons: 2a2f79274248390b80684ea3c4400bd374a15c90
+  RNScreens: 63fe8222c172a79f5c30dd1aefaeb369c6eb57b6
+  RNVectorIcons: 933948590e598ec50433d6f207242e5a7c1d6b7d
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
   SwiftProtobuf: 7773c4e96a99d7b8ab7cda0fc30a883732ff93b1
   Yoga: 348f8b538c3ed4423eb58a8e5730feec50bce372

--- a/ios/EspIdfProvisioning.mm
+++ b/ios/EspIdfProvisioning.mm
@@ -1,4 +1,8 @@
+#ifdef RCT_NEW_ARCH_ENABLED
+#import <RNEspIdfProvisioningSpec/RNEspIdfProvisioningSpec.h>
+#else
 #import <React/RCTBridgeModule.h>
+#endif
 
 @interface RCT_EXTERN_MODULE(EspIdfProvisioning, NSObject)
     RCT_EXTERN_METHOD(searchESPDevices:(NSString *)devicePrefix

--- a/turbo.json
+++ b/turbo.json
@@ -2,6 +2,7 @@
   "$schema": "https://turbo.build/schema.json",
   "tasks": {
     "build:android": {
+      "env": ["ORG_GRADLE_PROJECT_newArchEnabled"],
       "inputs": [
         "package.json",
         "android",
@@ -17,6 +18,7 @@
       "outputs": []
     },
     "build:ios": {
+      "env": ["RCT_NEW_ARCH_ENABLED"],
       "inputs": [
         "package.json",
         "*.podspec",


### PR DESCRIPTION
Fixes #73 

> [!NOTE]
> On android it assumes double as type instead of int for `security` param. So I added the necessary conversions in the module. Assuming problems with the new architecture codegen.