### PR TITLE
fix(#88): return empty list on empty wifi scan result

### DIFF
--- a/ios/EspIdfProvisioning.swift
+++ b/ios/EspIdfProvisioning.swift
@@ -148,6 +148,10 @@ class EspIdfProvisioning: NSObject {
             guard !invoked else { return }
 
             if error != nil {
+                if error?.code == ESPWiFiScanError.emptyResultCount.code {
+                  resolve([])
+                }
+
                 // Ignore error as per https://github.com/orbital-systems/react-native-esp-idf-provisioning/issues/22
                 // and https://github.com/espressif/esp-idf-provisioning-ios/issues/74
                 return


### PR DESCRIPTION
Fixes #88 (thanks to @barakataboujreich).